### PR TITLE
Expose Seed Nodes - MOABB

### DIFF
--- a/benchmarks/MOABB/train.py
+++ b/benchmarks/MOABB/train.py
@@ -368,6 +368,7 @@ def prepare_dataset_iterators(hparams):
         tmax=hparams["tmax"],
         save_prepared_dataset=hparams["save_prepared_dataset"],
         n_steps_channel_selection=hparams["n_steps_channel_selection"],
+        seed_nodes=hparams.get("seed_nodes", ["Cz"]),
     )
     return tail_path, datasets
 

--- a/benchmarks/MOABB/utils/dataio_iterators.py
+++ b/benchmarks/MOABB/utils/dataio_iterators.py
@@ -163,6 +163,7 @@ class LeaveOneSessionOut(object):
         tmax=None,
         save_prepared_dataset=None,
         n_steps_channel_selection=None,
+        seed_nodes=["Cz"],
     ):
         """This function returns the pre-processed datasets (training, validation and test sets).
 
@@ -310,18 +311,21 @@ class LeaveOneSessionOut(object):
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
             x_valid = sample_channels(
                 x_valid,
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
             x_test = sample_channels(
                 x_test,
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
 
         # swap axes: from (N_examples, C, T) to (N_examples, T, C)
@@ -382,6 +386,7 @@ class LeaveOneSubjectOut(object):
         tmax=None,
         save_prepared_dataset=None,
         n_steps_channel_selection=None,
+        seed_nodes=["Cz"],
     ):
         """This function returns the pre-processed datasets (training, validation and test sets).
 
@@ -562,18 +567,21 @@ class LeaveOneSubjectOut(object):
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
             x_valid = sample_channels(
                 x_valid,
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
             x_test = sample_channels(
                 x_test,
                 data_dict["adjacency_mtx"],
                 data_dict["channels"],
                 n_steps=n_steps_channel_selection,
+                seed_nodes=seed_nodes,
             )
 
         # swap axes: from (N_examples, C, T) to (N_examples, T, C)


### PR DESCRIPTION
Previously the number of channel selection steps was exposed in the hyper parameters, but the seed nodes were not. This will be a limitation when trying to integrate other datasets.

This PR exposes the seed_nodes argument in the hparams, or uses the default "Cz" channel if it is not present.

### Breaking Changes
- None

### Added Dependencies
- None