### PR TITLE
Fixed mne dependency issue

### DIFF
--- a/benchmarks/MOABB/extra-requirements.txt
+++ b/benchmarks/MOABB/extra-requirements.txt
@@ -1,4 +1,4 @@
-mne
+mne==1.6.1
 moabb
 orion
 orion[profet]


### PR DESCRIPTION
mne 1.7 does not work with current code, simply specified 1.6.1 as the the version of mne to be installed.